### PR TITLE
fixes TOR IP URL issue

### DIFF
--- a/docs/examples/block-tor.sh
+++ b/docs/examples/block-tor.sh
@@ -2,13 +2,13 @@
 
 # TOR exit node IPs are published. Get a list with connectivity to Fastly
 fsly_ip=$(dig +short global.ssl.fastly.net | head -1)
-tor_ips="https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=${fsly_ip}"
+tor_ips="https://check.torproject.org/torbulkexitlist?ip=${fsly_ip}"
 
 # Create a temp file to store ips
 tempfile=$(mktemp)
 
 # Get the IPs and store in file
-curl -s "${tor_ips}" | grep -v "^#" > $tempfile
+curl -Ls "${tor_ips}" | grep -v "^#" > $tempfile
 
 # Add a new block list "tor_ips"
 # This will fail harmlessly if the list is already defined


### PR DESCRIPTION
**Issue**: 

The existing curl to `https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=${fsly_ip}` now redirects to `https://check.torproject.org/torbulkexitlist?ip=${fsly_ip}`, which was not accounted for in the `curl` to get these IPs and causes the script to fail silently when run.

**Proposed fix**: 

This change uses the new URL to gather TOR IPs, as well as modifies the `curl` to get the IPs to follow redirects with `-L` in case the URL ever changes in the future.